### PR TITLE
Fix labels and service selector

### DIFF
--- a/charts/vespa/Chart.yaml
+++ b/charts/vespa/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.1
+version: 0.2.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/vespa/templates/service.yaml
+++ b/charts/vespa/templates/service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   name: {{ .Values.service.name }}
   labels:
-    {{- toYaml .Values.labels | nindent 4 }}
+    {{- include "vespa.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/vespa/templates/statefulset.yaml
+++ b/charts/vespa/templates/statefulset.yaml
@@ -3,7 +3,7 @@ kind: StatefulSet
 metadata:
   name: {{ .Values.statefulSet.name }}
   labels:
-    {{- toYaml .Values.labels | nindent 4 }}
+    {{- include "vespa.labels" . | nindent 4 }}
 spec:
   serviceName: {{ .Values.statefulSet.name }}
   {{- if not .Values.autoscaling.enabled }}

--- a/charts/vespa/templates/statefulset.yaml
+++ b/charts/vespa/templates/statefulset.yaml
@@ -11,7 +11,7 @@ spec:
   {{- end }}
   selector:
     matchLabels:
-      {{- toYaml .Values.selectorLabels | nindent 6 }}
+      {{- include "vespa.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       {{- with .Values.podAnnotations }}
@@ -19,6 +19,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
+        {{- include "vespa.labels" . | nindent 8 }}
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/vespa/values.yaml
+++ b/charts/vespa/values.yaml
@@ -26,13 +26,10 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
-podAnnotations: {}
-podLabels:
-  app: vespa
 
-selectorLabels:
-  app: vespa
-  
+# Additional annotations and labels to apply to pods
+podAnnotations: {}
+podLabels: {}
 
 statefulSet:
   name: vespa


### PR DESCRIPTION
Updates service selector labels to fix the document-index-service and applies common labels to all resources.

Currently Values.podLabels and Values.selectorLabels = `app: vespa`, but the service template is using vespa.selectorLabels
from _helpers.tpl causing the labels to mismatch and the service to not forward traffic to the pods.

`helm template .`

```
# Source: vespa/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: document-index-service
...
  selector:
    app.kubernetes.io/name: vespa
    app.kubernetes.io/instance: release-name
```


```
# Source: vespa/templates/statefulset.yaml
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: vespa
  labels:
    app: vespa
```

Thanks for making this helm chart by the way!