### PR TITLE
changing volume template

### DIFF
--- a/charts/vespa/templates/statefulset.yaml
+++ b/charts/vespa/templates/statefulset.yaml
@@ -60,8 +60,5 @@ spec:
   - metadata:
       name: {{ .metadata.name }}
     spec:
-      accessModes: {{ .spec.accessModes }}
-      resources:
-        requests:
-          storage: {{ .spec.resources.requests.storage }}
+      {{- toYaml .spec | nindent 6 }}
   {{- end }}


### PR DESCRIPTION
### **User description**
Changing the volumeRequestTemplate to pass the whole `.spec` in, rather than specific fields.

Fixes #21


___

### **PR Type**
Enhancement


___

### **Description**
- Updated the volume template in `statefulset.yaml` to pass the entire `.spec` object instead of specific fields.
- Removed explicit references to `accessModes` and `resources.requests.storage`.
- Improved template readability and maintainability by using the `toYaml` function.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>statefulset.yaml</strong><dd><code>Update volume template to pass entire `.spec` object</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
charts/vespa/templates/statefulset.yaml

<li>Changed volume template to pass the entire <code>.spec</code> object.<br> <li> Removed specific field references for <code>accessModes</code> and <br><code>resources.requests.storage</code>.<br> <li> Utilized <code>toYaml</code> function for better readability and maintainability.<br>


</details>
    

  </td>
  <td><a href="https://github.com/unoplat/vespa-helm-charts/pull/22/files#diff-050f5b3d038811d8836777f48dfb545c4379d8620a59abbcf112bb0ecd58e07a">+2/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

