### PR TITLE
Simplify pod label config

### DIFF
--- a/charts/vespa/templates/service.yaml
+++ b/charts/vespa/templates/service.yaml
@@ -12,6 +12,6 @@ spec:
       targetPort: {{ .targetPort }}
       protocol: TCP
       name: {{ .name }}
-    {{- end }}    
+    {{- end }}
   selector:
-    {{- include "vespa.selectorLabels" . | nindent 4 }}
+    {{- toYaml .Values.podLabels | nindent 4 }}

--- a/charts/vespa/templates/statefulset.yaml
+++ b/charts/vespa/templates/statefulset.yaml
@@ -11,7 +11,7 @@ spec:
   {{- end }}
   selector:
     matchLabels:
-      {{- toYaml .Values.selectorLabels | nindent 6 }}
+      {{- toYaml .Values.podLabels | nindent 6 }}
   template:
     metadata:
       {{- with .Values.podAnnotations }}
@@ -52,9 +52,9 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           env:
-          - name: VESPA_CONFIGSERVERS 
+          - name: VESPA_CONFIGSERVERS
             value: vespa-0.vespa.{{ .Release.Namespace }}.svc.cluster.local
-            
+
   volumeClaimTemplates:
   {{- range .Values.volumeClaimTemplates }}
   - metadata:

--- a/charts/vespa/values.yaml
+++ b/charts/vespa/values.yaml
@@ -30,17 +30,13 @@ podAnnotations: {}
 podLabels:
   app: vespa
 
-selectorLabels:
-  app: vespa
-  
-
 statefulSet:
   name: vespa
   ports:
     - containerPort: 19071
     - containerPort: 8081
-      
-podSecurityContext: 
+
+podSecurityContext:
   # fsGroup: 2000
 
 readinessProbe:
@@ -49,7 +45,7 @@ readinessProbe:
      port: 19071
      scheme: HTTP
 
-securityContext: 
+securityContext:
   # capabilities:
   #   drop:
   #   - ALL
@@ -87,7 +83,7 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
-resources: 
+resources:
   requests:
     memory: "1000Mi"
     cpu: "500m"
@@ -110,7 +106,7 @@ volumes: []
 #     optional: false
 
 # Additional volumeMounts on the output Deployment definition.
-volumeMounts: 
+volumeMounts:
   - name: vespa-storage
     mountPath: /opt/vespa/var/
 
@@ -132,4 +128,4 @@ volumeClaimTemplates:
          - ReadWriteOnce
        resources:
          requests:
-           storage: 1Gi    
+           storage: 1Gi


### PR DESCRIPTION
### **User description**
It seems that a similar change was accepted recently https://github.com/unoplat/vespa-helm-charts/pull/14 but was then reverted in https://github.com/unoplat/vespa-helm-charts/pull/16 (reason unclear). This has lead to the issue described in https://github.com/unoplat/vespa-helm-charts/issues/20. I think both the stateful set selector labels and the service selector labels should just always take the same value as the pod labels to avoid future issues. Happy to discuss in more detail if required.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Updated the service and stateful set selectors to use `podLabels` instead of `selectorLabels` to ensure consistency and avoid future issues.
- Removed the `selectorLabels` configuration from `values.yaml`.
- Cleaned up trailing whitespace and improved formatting in YAML files.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>service.yaml</strong><dd><code>Update service selector to use pod labels</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
charts/vespa/templates/service.yaml

<li>Updated the service selector to use pod labels instead of selector <br>labels.<br> <li> Removed trailing whitespace.<br>


</details>
    

  </td>
  <td><a href="https://github.com/unoplat/vespa-helm-charts/pull/23/files#diff-8ae1dcdcb2a887eb0f1ec199f1042677b655e69e2848475c6c97c0d509ca0566">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>statefulset.yaml</strong><dd><code>Update stateful set selector to use pod labels</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
charts/vespa/templates/statefulset.yaml

<li>Updated the stateful set selector to use pod labels instead of <br>selector labels.<br> <li> Removed trailing whitespace.<br>


</details>
    

  </td>
  <td><a href="https://github.com/unoplat/vespa-helm-charts/pull/23/files#diff-050f5b3d038811d8836777f48dfb545c4379d8620a59abbcf112bb0ecd58e07a">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>values.yaml</strong><dd><code>Remove selectorLabels and use podLabels in configurations</code></dd></summary>
<hr>
      
charts/vespa/values.yaml

<li>Removed <code>selectorLabels</code> and updated configurations to use <code>podLabels</code>.<br> <li> Cleaned up trailing whitespace and formatting.<br>


</details>
    

  </td>
  <td><a href="https://github.com/unoplat/vespa-helm-charts/pull/23/files#diff-345523b65d330299fad5058de7074669769dc06e8a925003b744f1e06b1ef347">+6/-10</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

