### PR TITLE
Added support for nodeSelector in helm

### DIFF
--- a/charts/vespa/templates/statefulset.yaml
+++ b/charts/vespa/templates/statefulset.yaml
@@ -54,6 +54,10 @@ spec:
           env:
           - name: VESPA_CONFIGSERVERS 
             value: vespa-0.vespa.{{ .Release.Namespace }}.svc.cluster.local
+      
+      {{- if $.Values.nodeSelector }}
+      nodeSelector: {{ toYaml $.Values.nodeSelector | nindent 8 }}
+      {{- end }}
             
   volumeClaimTemplates:
   {{- range .Values.volumeClaimTemplates }}


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Added support for `nodeSelector` in the Helm chart for Kubernetes deployments.
- The `nodeSelector` is conditionally included based on the presence of values in the Helm chart configuration.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>statefulset.yaml</strong><dd><code>Add nodeSelector support to Helm chart</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/vespa/templates/statefulset.yaml

<li>Added support for <code>nodeSelector</code> in the Helm chart.<br> <li> Conditional inclusion of <code>nodeSelector</code> based on values.<br>


</details>


  </td>
  <td><a href="https://github.com/unoplat/vespa-helm-charts/pull/25/files#diff-050f5b3d038811d8836777f48dfb545c4379d8620a59abbcf112bb0ecd58e07a">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information