### PR TITLE
add PDB support

### DIFF
--- a/charts/vespa/templates/pdb.yaml
+++ b/charts/vespa/templates/pdb.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.pdb.enabled -}}
+{{ if $.Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" -}}
+apiVersion: policy/v1
+{{- else -}}
+apiVersion: policy/v1beta1
+{{- end }}
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Values.pdb.name }}
+  labels:
+    {{- toYaml .Values.labels | nindent 4 }}
+spec:
+  {{- toYaml .Values.pdb.budget | nindent 2 }}
+  selector:
+    matchLabels:
+        {{- include "vespa.selectorLabels" . | nindent 6 }}
+{{- end -}}

--- a/charts/vespa/values.yaml
+++ b/charts/vespa/values.yaml
@@ -135,7 +135,7 @@ volumeClaimTemplates:
            storage: 1Gi    
 
 pdb:
-  enabled: true
+  enabled: false
   name: vespa-pdb
   budget:
     minAvailable: 1

--- a/charts/vespa/values.yaml
+++ b/charts/vespa/values.yaml
@@ -133,3 +133,9 @@ volumeClaimTemplates:
        resources:
          requests:
            storage: 1Gi    
+
+pdb:
+  enabled: true
+  name: vespa-pdb
+  budget:
+    minAvailable: 1


### PR DESCRIPTION
### Description
Added Pod Disruption Budget for better stability of the Vespa instance running. 

### Changes
- Added support for PDB. This will be disabled by default


### sample values yaml
```yaml
pdb:
  enabled: true
  name: vespa-pdb
  budget:
    minAvailable: 1
```

### output
```yaml
apiVersion: policy/v1beta1
kind: PodDisruptionBudget
metadata:
  name: vespa-pdb
  labels:
    app: vespa
spec:
  minAvailable: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: vespa
      app.kubernetes.io/instance: release-name
```